### PR TITLE
Fix warning that crashes on macOS Monterey

### DIFF
--- a/src/alforge/Open.php
+++ b/src/alforge/Open.php
@@ -13,7 +13,7 @@ class Open extends Forge
     {
         $cmdParts = explode(' ', $command);
 
-        if ($cmdParts[1]) {
+        if (isset($cmdParts[1])) {
             $this->respond("https://forge.laravel.com/servers/$cmdParts[0]/sites/$cmdParts[1]");
         } else {
             $this->respond("https://forge.laravel.com/servers/$cmdParts[0]");


### PR DESCRIPTION
Most probably it will fix #12.